### PR TITLE
Fix black checkboxes on hover

### DIFF
--- a/darkorange/darkorange.qss
+++ b/darkorange/darkorange.qss
@@ -16,7 +16,6 @@ QWidget
 QWidget:item:hover
 {
     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #ffa02f, stop: 1 #ca0619);
-    color: #000000;
 }
 
 QWidget:item:selected


### PR DESCRIPTION
Without this change, checkboxes that are checked show up as completely black when you hover over them. This is quite surprising, so make checkboxes show the same whether they are hovered over or not.