### PR TITLE
Fix more checkboxes of other QT types

### DIFF
--- a/darkorange/darkorange.qss
+++ b/darkorange/darkorange.qss
@@ -448,7 +448,13 @@ QRadioButton::indicator:hover, QCheckBox::indicator:hover
     border: 1px solid #ffaa00;
 }
 
-QCheckBox::indicator:checked
+QCheckBox::indicator:checked,
+QMenu::indicator:non-exclusive:checked,
+QGroupBox::indicator:checked,
+QTreeView::indicator:checked,
+QListView::indicator:checked,
+QTableView::indicator:checked,
+QColumnView::indicator:checked
 {
     image:url(:/images/checkbox.png);
 }


### PR DESCRIPTION
There are a few other checkbox types which were not showing up. I copy these from a different theme to try and ensure full coverage of the different checkbox types.

Unchecked box works ok, you see a black box for all the below types, so that is why I am not adding this for the unchecked version.